### PR TITLE
Rep and Science and Funds, oh my!

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Localization/en-us.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Localization/en-us.cfg
@@ -6,14 +6,20 @@ Localization
         #autoLOC_USI_WOLF_CURRENT_BIOME_GUI_NAME = WOLF biome
         #autoLOC_USI_WOLF_INVALID_DEPOT_PART_ATTACHMENT_MESSAGE = Depots must be detached from other WOLF parts before deployment.
         #autoLOC_USI_WOLF_INVALID_SITUATION_MESSAGE = Your vessel must be landed or orbiting in order to connect to a depot.
+        #autoLOC_USI_WOLF_INVALID_ORBIT_SITUATION_MESSAGE = Your vessel must be in a low orbit with eccentricity below 0.1 to connect to a orbital depot.
         #autoLOC_USI_WOLF_MISSING_DEPOT_MESSAGE = You must establish a depot in this biome first!
         #autoLOC_USI_WOLF_MISSING_RESOURCE_MESSAGE = Depot needs an additional (｢0｣) ｢1｣.
         #autoLOC_USI_WOLF_SUCCESSFUL_DEPLOYMENT_MESSAGE = Your infrastructure has expanded on ｢0｣!
+
+        // WOLF game params
+        #autoLOC_WOLF_RESOURCE_ABUNDANCE_MULTIPLIER_OPTION_TITLE = Resource Abundance Multiplier
+        #autoLOC_WOLF_RESOURCE_ABUNDANCE_MULTIPLIER_OPTION_TOOLTIP = Increase to have more harvestable resources on bodies other than the home world.
 
         // Depot messages
         #autoLOC_USI_WOLF_DEPOT_ALREADY_ESTABLISHED_MESSAGE = A depot has already been established here!
         #autoLOC_USI_WOLF_DEPOT_CANNOT_ADD_CREW_MESSAGE = Kerbals cannot live in this biome yet.
         #autoLOC_USI_WOLF_DEPOT_INVALID_SITUATION_MESSAGE = Can only estabish a depot when landed on the surface or in orbit.
+        #autoLOC_USI_WOLF_DEPOT_INVALID_ORBIT_SITUATION_MESSAGE = Orbital depots must be in a low orbit with eccentricity below 0.1
         #autoLOC_USI_WOLF_DEPOT_SUCCESSFUL_DEPLOYMENT_MESSAGE = Your depot has been established in ｢0｣ on ｢1｣!
         #autoLOC_USI_WOLF_DEPOT_SUCCESSFUL_SURVEY_MESSAGE = Resource survey completed in ｢0｣ on ｢1｣!
         #autoLOC_USI_WOLF_DEPOT_SURVEY_ALREADY_COMPLETE_MESSAGE = A survey has already been completed in this biome!
@@ -58,12 +64,18 @@ Localization
 
         // Transporter UI messages
         #autoLOC_USI_WOLF_TRANSPORTER_UI_INSUFFICIENT_PAYLOAD_MESSAGE = This transfer exceeds the available payload capacity.
-        #autoLOC_USI_WOLF_TRANSPORTER_UI_INSUFFICIENT_ORIGIN_RESOURCES_MESSAGE = This transfer exceeds the available payload capacity.
-        #autoLOC_USI_WOLF_TRANSPORTER_UI_NO_ROUTES_MESSAGE = This transfer exceeds the available payload capacity.
+        #autoLOC_USI_WOLF_TRANSPORTER_UI_INSUFFICIENT_ORIGIN_RESOURCES_MESSAGE = This transfer exceeds the availability at the origin depot.
+        #autoLOC_USI_WOLF_TRANSPORTER_UI_CANNOT_CANCEL_TRANSFER_MESSAGE = Cannot cancel this transfer. ｢0｣ is in use.
+        #autoLOC_USI_WOLF_TRANSPORTER_UI_NO_ROUTES_MESSAGE = There are currently no established routes.
         #autoLOC_USI_WOLF_TRASNPORTER_UI_CONFIRMATION_DIALOG_WINDOW_TITLE = Confirm Route Cancellation
         #autoLOC_USI_WOLF_TRANSPORTER_UI_CONFIRM_CANCEL_ROUTE_MESSAGE = Are you sure you want to cancel this route?
         #autoLOC_USI_WOLF_TRANSPORTER_UI_YES_MESSAGE = Yes
         #autoLOC_USI_WOLF_TRANSPORTER_UI_NO_MESSAGE = No
+
+        // Rewards messages
+        #autoLOC_USI_WOLF_REWARDS_FUNDS_ADDED_MESSAGE = You gained ｢0｣ Funds!
+        #autoLOC_USI_WOLF_REWARDS_SCIENCE_ADDED_MESSAGE = You gained ｢0｣ Science!
+        #autoLOC_USI_WOLF_REWARDS_REPUTATION_ADDED_MESSAGE = You gained ｢0｣ Reputation!
 
         // Part manufacturers
         #autoLOC_USI_WOLF_KOLONIZATION_DIVISION = USI - Kolonization Division
@@ -156,6 +168,7 @@ Localization
         #autoLOC_USI_WOLF_DRILL_RECIPE_SILICATES = Silicates
         #autoLOC_USI_WOLF_DRILL_RECIPE_SUBSTRATE = Substrate
         #autoLOC_USI_WOLF_DRILL_RECIPE_WATER = Water
+        #autoLOC_USI_WOLF_DRILL_RECIPE_XENON = Xenon
 
         // Extractor recipes
         #autoLOC_USI_WOLF_EXTRACTOR_RECIPE_OXYGEN = Oxygen

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Drill_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Drill_01.cfg
@@ -142,4 +142,12 @@ PART
 		InputResources = WaterVein,1
 		OutputResources = Water,1
 	}
+	MODULE
+	{
+		name = WOLF_RecipeOption
+		RecipeDisplayName = #autoLOC_USI_WOLF_DRILL_RECIPE_XENON
+
+		InputResources = XenonGasVein,1
+		OutputResources = Xenon,1
+	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Drill_02.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Drill_02.cfg
@@ -141,4 +141,12 @@ PART
 		InputResources = Power,5,WaterVein,5
 		OutputResources = Water,5
 	}
+	MODULE
+	{
+		name = WOLF_RecipeOption
+		RecipeDisplayName = #autoLOC_USI_WOLF_DRILL_RECIPE_XENON
+
+		InputResources = Power,5,XenonGasVein,5
+		OutputResources = Xenon,5
+	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/HopperFuel.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/HopperFuel.cfg
@@ -154,4 +154,20 @@ PART
 			DumpExcess = false
 		}
 	}
+	MODULE
+	{
+		name = WOLF_HopperSwapOption
+		ConverterName = Xenon
+		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
+		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
+
+		InputResources = Xenon,2
+
+		OUTPUT_RESOURCE
+		{
+			ResourceName = XenonGas
+			Ratio = 0.9259259
+			DumpExcess = false
+		}
+	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/HopperHarvesting.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/HopperHarvesting.cfg
@@ -108,12 +108,12 @@ PART
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = Dirt,1
+		InputResources = Dirt,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Dirt
-			Ratio = 0.0122477
+			Ratio = 0.0578704
 			DumpExcess = false
 		}
 	}
@@ -125,12 +125,12 @@ PART
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = ExoticMinerals,1
+		InputResources = ExoticMinerals,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = ExoticMinerals
-			Ratio = 0.0122477
+			Ratio = 0.0370370
 			DumpExcess = false
 		}
 	}
@@ -142,12 +142,12 @@ PART
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = Gypsum,1
+		InputResources = Gypsum,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Gypsum
-			Ratio = 0.0122477
+			Ratio = 0.0168350
 			DumpExcess = false
 		}
 	}
@@ -160,12 +160,12 @@ PART
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = Hydrates,1
+		InputResources = Hydrates,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Hydrates
-			Ratio = 0.0122477
+			Ratio = 0.0617284
 			DumpExcess = false
 		}
 	}
@@ -177,12 +177,12 @@ PART
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = MetallicOre,1
+		InputResources = MetallicOre,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = MetallicOre
-			Ratio = 0.0122477
+			Ratio = 0.0168350
 			DumpExcess = false
 		}
 	}
@@ -194,12 +194,12 @@ PART
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = Minerals,1
+		InputResources = Minerals,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Minerals
-			Ratio = 0.0122477
+			Ratio = 0.0342935
 			DumpExcess = false
 		}
 	}
@@ -211,12 +211,12 @@ PART
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = Ore,1
+		InputResources = Ore,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Ore
-			Ratio = 0.0122477
+			Ratio = 0.0092593
 			DumpExcess = false
 		}
 	}
@@ -228,12 +228,12 @@ PART
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = RareMetals,1
+		InputResources = RareMetals,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = RareMetals
-			Ratio = 0.0122477
+			Ratio = 0.0118708
 			DumpExcess = false
 		}
 	}
@@ -245,12 +245,12 @@ PART
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = Silicates,1
+		InputResources = Silicates,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Silicates
-			Ratio = 0.0122477
+			Ratio = 0.0370370
 			DumpExcess = false
 		}
 	}
@@ -262,12 +262,12 @@ PART
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = Substrate,1
+		InputResources = Substrate,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Substrate
-			Ratio = 0.0122477
+			Ratio = 0.0578704
 			DumpExcess = false
 		}
 	}
@@ -279,48 +279,47 @@ PART
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = Water,1
+		InputResources = Water,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Water
-			Ratio = 0.0122477
+			Ratio = 0.0925926
 			DumpExcess = false
 		}
 	}
 
-	MODULE
+	MODULE:NEEDS[Karbonite]
 	{
 		name = WOLF_HopperSwapOption
 		ConverterName = Karbonite
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = Karbonite,1
+		InputResources = Karbonite,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Karbonite
-			Ratio = 0.0122477
+			Ratio = 0.0370370
 			DumpExcess = false
 		}
 	}
 
-	MODULE
+	MODULE:NEEDS[Karbonite]
 	{
 		name = WOLF_HopperSwapOption
 		ConverterName = Karborundum
 		StartActionName = #autoLOC_USI_WOLF_HOPPER_START_MESSAGE
 		StopActionName = #autoLOC_USI_WOLF_HOPPER_STOP_MESSAGE
 
-		InputResources = Karborundum,1
+		InputResources = Karborundum,2
 
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Karborundum
-			Ratio = 0.0122477
+			Ratio = 0.0159642
 			DumpExcess = false
 		}
 	}
-
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/WOLF.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/WOLF.cfg
@@ -1,4 +1,5 @@
 WOLF_CONFIGURATION
 {
-	AllowedHarvestableResources = Dirt,ExoticMinerals,Gypsum,Hydrates,MetallicOre,Minerals,Ore,Oxygen,RareMetals,Silicates,Substrate,Water
+	AllowedHarvestableResources = Dirt,ExoticMinerals,Gypsum,Hydrates,MetallicOre,Minerals,Ore,Oxygen,RareMetals,Silicates,Substrate,Water,XenonGas
+	BlacklistedHomeworldResources = ExoticMinerals,RareMetals
 }

--- a/Source/WOLF/WOLF.Tests.Unit/When_exploring_configuration.cs
+++ b/Source/WOLF/WOLF.Tests.Unit/When_exploring_configuration.cs
@@ -51,5 +51,21 @@ namespace WOLF.Tests.Unit
             Assert.Contains(resources, r => r == "Ore");
             Assert.Contains(resources, r => r == "Oxygen");
         }
+
+        [Fact]
+        public void Can_blacklist_resources_on_homeworld()
+        {
+            var configuration = new Configuration();
+
+            configuration.SetHarvestableResources("ExoticMinerals,Ore");
+            configuration.SetBlacklistedHomeworldResources("ExoticMinerals");
+            var resources = configuration.AllowedHarvestableResourcesOnHomeworld;
+
+            Assert.NotNull(resources);
+            Assert.NotEmpty(resources);
+            Assert.Single(resources);
+            Assert.Contains(resources, r => r == "Ore");
+            Assert.DoesNotContain(resources, r => r == "ExoticMinerals");
+        }
     }
 }

--- a/Source/WOLF/WOLF/Configuration.cs
+++ b/Source/WOLF/WOLF/Configuration.cs
@@ -7,6 +7,7 @@ namespace WOLF
     public class ConfigurationFromFile
     {
         public string AllowedHarvestableResources { get; set; }
+        public string BlacklistedHomeworldResources { get; set; }
     }
 
     public class Configuration
@@ -16,16 +17,46 @@ namespace WOLF
         public static readonly List<string> DefaultHarvestableResources = new List<string>
         {
             "Dirt", "ExoticMinerals", "Gypsum", "Hydrates", "MetallicOre", "Minerals",
-            "Ore", "Oxygen", "RareMetals", "Silicates", "Substrate", "Water"
+            "Ore", "Oxygen", "RareMetals", "Silicates", "Substrate", "Water", "XenonGas"
         };
 
-        public List<string> AllowedHarvestableResources { get; set; }
+        private List<string> _allowedHarvestableResources;
+        private List<string> _allowedHarvestableResourcesOnHomeworld;
+        private List<string> _blacklistedHomeworldResources;
+
+        public List<string> AllowedHarvestableResources
+        {
+            get
+            {
+                if (_allowedHarvestableResources == null || _allowedHarvestableResources.Count < 1)
+                {
+                    _allowedHarvestableResources = DefaultHarvestableResources;
+                }
+
+                return _allowedHarvestableResources;
+            }
+        }
+
+        public List<string> AllowedHarvestableResourcesOnHomeworld
+        {
+            get
+            {
+                if (_allowedHarvestableResourcesOnHomeworld == null)
+                {
+                    _allowedHarvestableResourcesOnHomeworld = AllowedHarvestableResources
+                        .Where(r => !_blacklistedHomeworldResources.Contains(r))
+                        .ToList();
+                }
+
+                return _allowedHarvestableResourcesOnHomeworld;
+            }
+        }
 
         public static List<string> ParseHarvestableResources(string resources)
         {
             if (string.IsNullOrEmpty(resources))
             {
-                return DefaultHarvestableResources;
+                return new List<string>();
             }
             else
             {
@@ -39,15 +70,31 @@ namespace WOLF
             }
         }
 
-        public void SetHarvestableResources(List<string> resources)
+        public void SetBlacklistedHomeworldResources(List<string> resources)
         {
-            if (resources == null || resources.Count < 1)
+            if (resources == null)
             {
-                AllowedHarvestableResources = DefaultHarvestableResources;
+                _blacklistedHomeworldResources = new List<string>();
             }
             else
             {
-                AllowedHarvestableResources = resources
+                _blacklistedHomeworldResources = resources
+                    .Distinct()
+                    .OrderBy(r => r)
+                    .ToList();
+            }
+        }
+
+        public void SetBlacklistedHomeworldResources(string resourceList)
+        {
+            _blacklistedHomeworldResources = ParseHarvestableResources(resourceList);
+        }
+
+        public void SetHarvestableResources(List<string> resources)
+        {
+            if (resources != null)
+            {
+                _allowedHarvestableResources = resources
                     .Distinct()
                     .OrderBy(r => r)
                     .ToList();
@@ -56,7 +103,7 @@ namespace WOLF
 
         public void SetHarvestableResources(string resourceList)
         {
-            AllowedHarvestableResources = ParseHarvestableResources(resourceList);
+            _allowedHarvestableResources = ParseHarvestableResources(resourceList);
         }
     }
 }

--- a/Source/WOLF/WOLF/Depot.cs
+++ b/Source/WOLF/WOLF/Depot.cs
@@ -172,7 +172,7 @@ namespace WOLF
 
                 stream.Incoming += resource.Value;
 
-                // This should never happen since we don't allow removing providers from WOLF but just to be safe...
+                // Sanity check
                 if (stream.Incoming < 0)
                     stream.Incoming = 0;
             }

--- a/Source/WOLF/WOLF/GUI/WOLF_RouteMonitor.cs
+++ b/Source/WOLF/WOLF/GUI/WOLF_RouteMonitor.cs
@@ -27,7 +27,7 @@ namespace WOLF
 
         public Vector2 DrawWindow(Vector2 scrollPosition)
         {
-            var newScrollPosition = GUILayout.BeginScrollView(scrollPosition, _scrollStyle, GUILayout.Width(680), GUILayout.Height(830));
+            var newScrollPosition = GUILayout.BeginScrollView(scrollPosition, _scrollStyle, GUILayout.Width(680), GUILayout.Height(800));
             GUILayout.BeginVertical();
 
             try

--- a/Source/WOLF/WOLF/GUI/WOLF_ScenarioMonitor.cs
+++ b/Source/WOLF/WOLF/GUI/WOLF_ScenarioMonitor.cs
@@ -45,6 +45,7 @@ namespace WOLF
         private Rect _windowPosition = new Rect(300, 60, 700, 460);
         private GUIStyle _windowStyle;
         private int _windowId;
+        private GUIStyle _dividerStyle;
         private ApplicationLauncherButton _wolfButton;
         private IRegistryCollection _wolfRegistry;
         private WOLF_ScenarioModule _wolfScenario;
@@ -179,6 +180,12 @@ namespace WOLF
             {
                 fontSize = 10
             };
+            _dividerStyle = new GUIStyle
+            {
+                margin = new RectOffset(0, 0, 4, 4),
+                fixedHeight = 1f
+            };
+
             _hasInitStyles = true;
         }
 
@@ -226,6 +233,12 @@ namespace WOLF
             }
             GUILayout.EndHorizontal();
 
+            // Display filter buttons
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Filters", _labelStyle, GUILayout.Width(70));
+            GUILayout.Label("<color=#FFD900>Coming soon...</color>", _labelStyle, GUILayout.Width(300));
+            GUILayout.EndHorizontal();
+
             // Show the UI for the currently selected tab
             switch (activeTab)
             {
@@ -264,7 +277,7 @@ namespace WOLF
         /// </summary>
         private void ShowResources(Func<IResourceStream, bool> resourceFilter, string incomingHeaderLabel = "Incoming", string outgoingHeaderLabel = "Outgoing", string availableHeaderLabel = "Available")
         {
-            _scrollPos = GUILayout.BeginScrollView(_scrollPos, _scrollStyle, GUILayout.Width(680), GUILayout.Height(830));
+            _scrollPos = GUILayout.BeginScrollView(_scrollPos, _scrollStyle, GUILayout.Width(680), GUILayout.Height(800));
             GUILayout.BeginVertical();
 
             try

--- a/Source/WOLF/WOLF/Messenger.cs
+++ b/Source/WOLF/WOLF/Messenger.cs
@@ -7,6 +7,7 @@ namespace WOLF
         public static string INVALID_DEPOT_PART_ATTACHMENT_MESSAGE = "#autoLOC_USI_WOLF_INVALID_DEPOT_PART_ATTACHMENT_MESSAGE"; // "Depots must be detached from other WOLF parts before deployment.";
         public static string INVALID_HOPPER_PART_ATTACHMENT_MESSAGE = "#autoLOC_USI_WOLF_INVALID_HOPPER_PART_ATTACHMENT_MESSAGE"; // "Hoppers must be detached from other WOLF parts before deployment.";
         public static string INVALID_SITUATION_MESSAGE = "#autoLOC_USI_WOLF_INVALID_SITUATION_MESSAGE"; // "Your vessel must be landed or orbiting in order to connect to a depot.";
+        public static string INVALID_ORBIT_SITUATION_MESSAGE = "#autoLOC_USI_WOLF_INVALID_ORBIT_SITUATION_MESSAGE"; // "Your vessel must be in a low orbit with eccentricity below 0.1 to connect to a orbital depot.";
         public static string MISSING_DEPOT_MESSAGE = "#autoLOC_USI_WOLF_MISSING_DEPOT_MESSAGE"; // "You must establish a depot in this biome first!";
         public static string MISSING_RESOURCE_MESSAGE = "#autoLOC_USI_WOLF_MISSING_RESOURCE_MESSAGE"; // "Depot needs an additional ({0}) {1}.";
         public static string SUCCESSFUL_DEPLOYMENT_MESSAGE = "#autoLOC_USI_WOLF_SUCCESSFUL_DEPLOYMENT_MESSAGE"; // "Your infrastructure has expanded on {0}!";
@@ -29,6 +30,10 @@ namespace WOLF
             if (Localizer.TryGetStringByTag("#autoLOC_USI_WOLF_INVALID_SITUATION_MESSAGE", out string invalidSituationMessage))
             {
                 INVALID_SITUATION_MESSAGE = invalidSituationMessage;
+            }
+            if (Localizer.TryGetStringByTag("#autoLOC_USI_WOLF_INVALID_ORBIT_SITUATION_MESSAGE", out string invalidOrbitSituationMessage))
+            {
+                INVALID_ORBIT_SITUATION_MESSAGE = invalidOrbitSituationMessage;
             }
             if (Localizer.TryGetStringByTag("#autoLOC_USI_WOLF_MISSING_DEPOT_MESSAGE", out string missingDepotMessage))
             {

--- a/Source/WOLF/WOLF/Modules/WOLF_AbstractPartModule.cs
+++ b/Source/WOLF/WOLF/Modules/WOLF_AbstractPartModule.cs
@@ -109,6 +109,8 @@ namespace WOLF
             vessel.checkLanded();
             vessel.checkSplashed();
 
+            ExperimentSituations experimentSituation = ScienceUtil.GetExperimentSituation(vessel);
+
             switch (vessel.situation)
             {                
                 case Situations.LANDED:
@@ -119,7 +121,28 @@ namespace WOLF
                     else
                         return GetVesselLandedAtBiome(vessel.landedAt);
                 case Situations.ORBITING:
-                    return "Orbit";
+                    var altitude = ScienceUtil.GetExperimentSituation(vessel) == ExperimentSituations.InSpaceLow
+                        ? "" : "High";
+                    var ecc = vessel.GetOrbit().eccentricity > 0.1d
+                        ? "Eccentric" : "";
+                    var suffix = string.Empty;
+                    if (!string.IsNullOrEmpty(altitude))
+                    {
+                        suffix = altitude;
+                    }
+                    if (!string.IsNullOrEmpty(ecc))
+                    {
+                        if (!string.IsNullOrEmpty(suffix))
+                        {
+                            suffix += "/";
+                        }
+                        suffix += ecc;
+                    }
+                    if (!string.IsNullOrEmpty(suffix))
+                    {
+                        suffix = ":Too " + suffix;
+                    }
+                    return $"Orbit{suffix}";
                 default:
                     return string.Empty;
             }

--- a/Source/WOLF/WOLF/Modules/WOLF_ConverterModule.cs
+++ b/Source/WOLF/WOLF/Modules/WOLF_ConverterModule.cs
@@ -21,6 +21,10 @@ namespace WOLF
             {
                 return Messenger.INVALID_SITUATION_MESSAGE;
             }
+            if (biome.StartsWith("Orbit") && biome != "Orbit")
+            {
+                return Messenger.INVALID_ORBIT_SITUATION_MESSAGE;
+            }
             if (!_registry.HasDepot(body, biome))
             {
                 return Messenger.MISSING_DEPOT_MESSAGE;
@@ -61,6 +65,7 @@ namespace WOLF
             var crewModule = vessel.vesselModules
                 .Where(m => m is WOLF_CrewModule)
                 .FirstOrDefault() as WOLF_CrewModule;
+            IRecipe crewRecipe;
             if (crewModule == null)
             {
                 DisplayMessage("BUG: Could not find crew module.");
@@ -73,7 +78,7 @@ namespace WOLF
             }
             else
             {
-                var crewRecipe = crewModule.GetCrewRecipe();
+                crewRecipe = crewModule.GetCrewRecipe();
                 recipes.Add(crewRecipe);
             }
 
@@ -94,6 +99,16 @@ namespace WOLF
             }
 
             DisplayMessage(string.Format(Messenger.SUCCESSFUL_DEPLOYMENT_MESSAGE, body));
+
+            // Add rewards
+            if (crewRecipe != null)
+            {
+                var totalCrewPoints = crewRecipe.OutputIngredients
+                    .Sum(i => i.Value);
+
+                RewardsManager.AddReputation(totalCrewPoints);
+            }
+
             Poof.GoPoof(vessel);
         }
 

--- a/Source/WOLF/WOLF/Modules/WOLF_DepotModule.cs
+++ b/Source/WOLF/WOLF/Modules/WOLF_DepotModule.cs
@@ -12,6 +12,7 @@ namespace WOLF
         private static string DEPOT_ALREADY_ESTABLISHED_MESSAGE = "#autoLOC_USI_WOLF_DEPOT_ALREADY_ESTABLISHED_MESSAGE"; // "A depot has already been established here!";
         private static string ESTABLISH_DEPOT_GUI_NAME = "#autoLOC_USI_WOLF_ESTABLISH_DEPOT_GUI_NAME"; // "Establish depot."
         private static string INVALID_SITUATION_MESSAGE = "#autoLOC_USI_WOLF_DEPOT_INVALID_SITUATION_MESSAGE"; // "Can only estabish a depot when landed on the surface or in orbit.";
+        private static string INVALID_ORBIT_SITUATION_MESSAGE = "#autoLOC_USI_WOLF_DEPOT_INVALID_ORBIT_SITUATION_MESSAGE"; // "Orbital depots must be in a low orbit with eccentricity below 0.1";
         private static string SUCCESSFUL_DEPLOYMENT_MESSAGE = "#autoLOC_USI_WOLF_DEPOT_SUCCESSFUL_DEPLOYMENT_MESSAGE"; // "Your depot has been established at {0} on {1}!";
         private static string SUCCESSFUL_SURVEY_MESSAGE = "#autoLOC_USI_WOLF_DEPOT_SUCCESSFUL_SURVEY_MESSAGE"; // "Survey completed at {0} on {1}!";
         private static string SURVEY_ALREADY_COMPLETED_MESSAGE = "#autoLOC_USI_WOLF_DEPOT_SURVEY_ALREADY_COMPLETE_MESSAGE"; // "A survey has already been completed in this biome!";
@@ -52,13 +53,16 @@ namespace WOLF
 
         protected Dictionary<string,int> CalculateAbundance(HarvestTypes[] harvestTypes)
         {
-            return ResourceManager.GetResourceAbundance(
+            var abundance = ResourceManager.GetResourceAbundance(
                 bodyIndex: FlightGlobals.currentMainBody.flightGlobalsIndex,
                 altitude: vessel.altitude,
                 latitude: vessel.latitude,
                 longitude: vessel.longitude,
                 harvestTypes: harvestTypes,
-                config: _scenario.Configuration);
+                config: _scenario.Configuration,
+                forHomeworld: FlightGlobals.currentMainBody.isHomeWorld);
+
+            return abundance;
         }
 
         protected override void ConnectToDepot()
@@ -75,6 +79,11 @@ namespace WOLF
             if (biome == string.Empty)
             {
                 DisplayMessage(INVALID_SITUATION_MESSAGE);
+                return;
+            }
+            if (biome.StartsWith("Orbit") && biome != "Orbit")
+            {
+                DisplayMessage(INVALID_ORBIT_SITUATION_MESSAGE);
                 return;
             }
 
@@ -131,6 +140,9 @@ namespace WOLF
                 depot.NegotiateProvider(harvestableResources);
 
                 DisplayMessage(string.Format(SUCCESSFUL_SURVEY_MESSAGE, biome, body));
+
+                // Add rewards
+                RewardsManager.AddScience();
             }
             else
             {
@@ -174,6 +186,10 @@ namespace WOLF
             if (Localizer.TryGetStringByTag("#autoLOC_USI_WOLF_DEPOT_INVALID_SITUATION_MESSAGE", out string situationMessage))
             {
                 INVALID_SITUATION_MESSAGE = situationMessage;
+            }
+            if (Localizer.TryGetStringByTag("#autoLOC_USI_WOLF_DEPOT_INVALID_ORBIT_SITUATION_MESSAGE", out string orbitSituationMessage))
+            {
+                INVALID_ORBIT_SITUATION_MESSAGE = orbitSituationMessage;
             }
             if (Localizer.TryGetStringByTag("#autoLOC_USI_WOLF_DEPOT_SUCCESSFUL_DEPLOYMENT_MESSAGE", out string deploySuccessMessage))
             {

--- a/Source/WOLF/WOLF/Modules/WOLF_HopperModule.cs
+++ b/Source/WOLF/WOLF/Modules/WOLF_HopperModule.cs
@@ -58,6 +58,11 @@ namespace WOLF
                 Messenger.DisplayMessage(Messenger.INVALID_SITUATION_MESSAGE);
                 return;
             }
+            if (biome.StartsWith("Orbit") && biome != "Orbit")
+            {
+                Messenger.DisplayMessage(Messenger.INVALID_ORBIT_SITUATION_MESSAGE);
+                return;
+            }
             if (!_registry.HasDepot(body, biome))
             {
                 Messenger.DisplayMessage(Messenger.MISSING_DEPOT_MESSAGE);

--- a/Source/WOLF/WOLF/Modules/WOLF_ScenarioModule.cs
+++ b/Source/WOLF/WOLF/Modules/WOLF_ScenarioModule.cs
@@ -21,17 +21,21 @@ namespace WOLF
         {
             var configNodes = GameDatabase.Instance.GetConfigNodes("WOLF_CONFIGURATION");
             var allowedResources = new List<string>();
+            var blacklistedResources = new List<string>();
 
             foreach (var node in configNodes)
             {
                 var configFromFile = ResourceUtilities.LoadNodeProperties<ConfigurationFromFile>(node);
                 var resources = Configuration.ParseHarvestableResources(configFromFile.AllowedHarvestableResources);
+                var blacklist = Configuration.ParseHarvestableResources(configFromFile.BlacklistedHomeworldResources);
 
                 allowedResources.AddRange(resources);
+                blacklistedResources.AddRange(blacklist);
             }
 
             var config = new Configuration();
             config.SetHarvestableResources(allowedResources);
+            config.SetBlacklistedHomeworldResources(blacklistedResources);
 
             return config;
         }

--- a/Source/WOLF/WOLF/RewardsManager.cs
+++ b/Source/WOLF/WOLF/RewardsManager.cs
@@ -1,0 +1,60 @@
+﻿using KSP.Localization;
+
+namespace WOLF
+{
+    public static class RewardsManager
+    {
+        private static readonly double FUNDS_PER_PAYLOAD_UNIT = 100d;
+        private static readonly float SCIENCE_PER_BIOME = 100f;
+        private static readonly float REP_PER_CREW_POINT = 10f;
+
+        private static readonly string FUNDS_ADDED_MESSAGE = "#autoLOC_USI_WOLF_REWARDS_FUNDS_ADDED_MESSAGE";  // "You gained {0} Funds!";
+        private static readonly string REPUTATION_ADDED_MESSAGE = "#autoLOC_USI_WOLF_REWARDS_SCIENCE_ADDED_MESSAGE";  // "You gained {0} Science!";
+        private static readonly string SCIENCE_ADDED_MESSAGE = "#autoLOC_USI_WOLF_REWARDS_REPUTATION_ADDED_MESSAGE";  // "You gained {0} Reputation!";
+
+        static RewardsManager()
+        {
+            if (Localizer.TryGetStringByTag("#autoLOC_USI_WOLF_REWARDS_FUNDS_ADDED_MESSAGE", out string fundsAddedMessage))
+            {
+                FUNDS_ADDED_MESSAGE = fundsAddedMessage;
+            }
+            if (Localizer.TryGetStringByTag("#autoLOC_USI_WOLF_REWARDS_REPUTATION_ADDED_MESSAGE", out string repAddedMessage))
+            {
+                REPUTATION_ADDED_MESSAGE = repAddedMessage;
+            }
+            if (Localizer.TryGetStringByTag("#autoLOC_USI_WOLF_REWARDS_SCIENCE_ADDED_MESSAGE", out string scienceAddedMessage))
+            {
+                SCIENCE_ADDED_MESSAGE = scienceAddedMessage;
+            }
+        }
+
+        public static void AddFunds(int payload)
+        {
+            if (Funding.Instance != null)
+            {
+                var funds = FUNDS_PER_PAYLOAD_UNIT * payload;
+                Funding.Instance.AddFunds(funds, TransactionReasons.ContractReward);
+                Messenger.DisplayMessage(string.Format(FUNDS_ADDED_MESSAGE, funds.ToString("F0")));
+            }
+        }
+
+        public static void AddReputation(int crewPoints)
+        {
+            if (Reputation.Instance != null)
+            {
+                var rep = REP_PER_CREW_POINT * crewPoints;
+                Reputation.Instance.AddReputation(rep, TransactionReasons.ContractReward);
+                Messenger.DisplayMessage(string.Format(REPUTATION_ADDED_MESSAGE, rep.ToString("F0")));
+            }
+        }
+
+        public static void AddScience()
+        {
+            if (ResearchAndDevelopment.Instance != null)
+            {
+                ResearchAndDevelopment.Instance.AddScience(SCIENCE_PER_BIOME, TransactionReasons.ContractReward);
+                Messenger.DisplayMessage(string.Format(SCIENCE_ADDED_MESSAGE, SCIENCE_PER_BIOME.ToString("F0")));
+            }
+        }
+    }
+}

--- a/Source/WOLF/WOLF/WOLF.csproj
+++ b/Source/WOLF/WOLF/WOLF.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Poof.cs" />
     <Compile Include="ResourceManager.cs" />
     <Compile Include="ResourceStream.cs" />
+    <Compile Include="RewardsManager.cs" />
     <Compile Include="Route.cs" />
     <Compile Include="ScenarioPersister.cs" />
     <Compile Include="Interfaces\IPersistenceAware.cs" />
@@ -101,6 +102,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Recipe.cs" />
     <Compile Include="Modules\WOLF_ConverterModule.cs" />
+    <Compile Include="WOLF_GameParameters.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/WOLF/WOLF/WOLF_GameParameters.cs
+++ b/Source/WOLF/WOLF/WOLF_GameParameters.cs
@@ -1,0 +1,33 @@
+﻿namespace WOLF
+{
+    public class WOLF_GameParameters : GameParameters.CustomParameterNode
+    {
+        [GameParameters.CustomIntParameterUI(
+            "#autoLOC_WOLF_RESOURCE_ABUNDANCE_MULTIPLIER_OPTION_TITLE",
+            autoPersistance = true, minValue = 1, maxValue = 10, stepSize = 1,
+            toolTip = "#autoLOC_WOLF_RESOURCE_ABUNDANCE_MULTIPLIER_OPTION_TOOLTIP")]
+        public int ResourceAbundanceMultiplier = 1;
+
+        public static int ResourceAbundanceMultiplierValue
+        {
+            get
+            {
+                var options = HighLogic.CurrentGame.Parameters.CustomParams<WOLF_GameParameters>();
+
+                return options.ResourceAbundanceMultiplier;
+            }
+        }
+
+        public override string Section => "WOLF";
+
+        public override string DisplaySection => "WOLF";
+
+        public override string Title => string.Empty;
+
+        public override int SectionOrder => 1;
+
+        public override GameParameters.GameMode GameMode => GameParameters.GameMode.ANY;
+
+        public override bool HasPresets => false;
+    }
+}


### PR DESCRIPTION
- WOLF events reward funds, science and reputation now
- Orbit biome is now restricted to "low" orbits with eccentricity < 0.1
- Added ExoticMinerals and RareMetals to a harvestables blacklist on the home planet
- Added Xenon as a harvestable resource
- Fractional route costs are all rounded up now to prevent "free" low mass/low dV routes
- Resource abundance off the home planet has a multiplier slider in the difficulty settings now
- Adjusted the resource output ratios of the harvester hopper
- New routes are now added to the manage transfers window on open (instead of on start)
- Fixed some localization issues